### PR TITLE
Downgrade to wasmtime 0.36.0

### DIFF
--- a/wasm/Dockerfile.emsdk3
+++ b/wasm/Dockerfile.emsdk3
@@ -41,7 +41,8 @@ RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$
     && mv /opt/wasi-sdk-${WASI_VERSION}.0 ${WASI_SDK_PATH}
 
 # wasmtime
-RUN curl https://wasmtime.dev/install.sh -sSf | bash
+RUN curl https://wasmtime.dev/install.sh -sSf -o /root/install-wasmtime.sh && \
+    bash /root/install-wasmtime.sh --version v0.36.0
 
 # wasix POSIX stubs, ctypes deps
 RUN /root/install-wasix.sh


### PR DESCRIPTION
wasmtime 0.37.0 seems to have a much smaller call stack size. Several
test cases with deep recursion are crashing the runtime.

See: https://github.com/bytecodealliance/wasmtime/issues/4214